### PR TITLE
Including 'r' in standardplots

### DIFF
--- a/standardplots
+++ b/standardplots
@@ -247,6 +247,9 @@ for (i, cond) in enumerate(('none', '$start-5m to +55m')):
 if not NoWgt:
     todo.append( mk_weight_plot(s) )
 
+# Just to do a 'r' to show the MS info at the very end
+todo.append("r")
+
 try:
     jplotter.run_plotter(command.scripted(*todo), debug=('-d' in opts))
 except:


### PR DESCRIPTION
In standardplots, I added an extra line to execute "r" at the very end, after creating all plots.
This would allow us to easily get the setup information at the same time as we run standardplots. Otherwise, we had to enter jplotter to only run it during a typical post-processing.
