### PR TITLE
Removing trailing spaces in output message

### DIFF
--- a/jplotter.py
+++ b/jplotter.py
@@ -1780,7 +1780,7 @@ def mk_output(pfx, items, maxlen):
         acc[-1] += " {0}".format(item)
         return acc
     for l in reduce(reducer, items, lines):
-        print l
+        print l.strip()
 
 
 


### PR DESCRIPTION
Under the current version, when you run "r" to show the summary of a MS file you get a trailing space in the output for the line(s) of "listAntennas: ....". This is created by line 565 in jplotter.py:

mk_output(prng(pfx+" "), map(lambda (ant,id): "{0} ({1: >2}) ".format(ant, id),
                         self.mappings.baselineMap.antennas()), 80)
The space after ({1: >2}) " is written even when it is the last element for that line in the output.

However, to fix that I propose modifying the mk_output function to trim all spaces at the beginning/ending of each printed line.
