### PR TITLE
Fixing integer-division compatibility in Py3

### DIFF
--- a/jplotter.py
+++ b/jplotter.py
@@ -739,7 +739,7 @@ class jplotter:
                 # Now we know we can safely replace strings -> values (and remove whitespace)
                 if nchan:
                     replacer = lambda x : hvutil.sub(x, [("\s+", ""), (re.compile(r"all"), "first:last"), \
-                                                         ("first", "0"), ("mid", repr(nchan/2)), ("last", repr(nchan-1))])
+                                                         ("first", "0"), ("mid", repr(nchan//2)), ("last", repr(nchan-1))])
                 else:
                     replacer = lambda x : hvutil.sub(x, [("\s+", "")])
                 expander = lambda x : hvutil.expand_string_range(replacer(x))


### PR DESCRIPTION
In Py3 a division of two integers returns a float.
This caused that the 'mid' keyword to select channels was breaking jplotter as it was returning a float (e.g. 32.0) when an integer (e.g. 32) was expected.
This may be the quickest fix I have ever done :-)